### PR TITLE
fixing light interacting with volumetric lighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.cs text
+*.md text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sln text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary

--- a/BabboSettings/LightController.cs
+++ b/BabboSettings/LightController.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
+using UnityEngine.Experimental.Rendering.HDPipeline;
 
 namespace BabboSettings
 {
-	public class LightController : Module
+    public class LightController : Module
 	{
 		#region Settings
 		public bool LIGHT_ENABLED = false;
@@ -21,6 +19,7 @@ namespace BabboSettings
 		#endregion
 
 		private Light light;
+        private HDAdditionalLightData additionalLightData;
 		public readonly string EmptyCookieName = "None";
 		private Dictionary<string, Texture2D> Cookies = new Dictionary<string, Texture2D>();
 
@@ -31,7 +30,11 @@ namespace BabboSettings
 
 			var camera = cameraController.mainCamera;
 			light = gameObject.AddComponent<Light>();
-			light.type = LightType.Spot;
+            
+            additionalLightData = gameObject.AddComponent<HDAdditionalLightData>();
+            additionalLightData.volumetricDimmer = 0;
+
+            light.type = LightType.Spot;
 			light.color = LIGHT_COLOR;
 			light.intensity = LIGHT_INTENSITY;
 			light.range = LIGHT_RANGE;
@@ -67,11 +70,11 @@ namespace BabboSettings
 				light.intensity = LIGHT_INTENSITY;
 				light.color = LIGHT_COLOR;
 				light.cookie = Cookies[LIGHT_COOKIE];
-
-				// move relative to camera
+                
+                // move relative to camera
 				var camera = cameraController.mainCamera;
 				light.transform.position = camera.transform.TransformPoint(LIGHT_POSITION);
-				light.transform.rotation = camera.transform.rotation;
+                light.transform.rotation = camera.transform.rotation;
 			}
 			else {
 				light.intensity = 0;

--- a/SXL Mods.sln
+++ b/SXL Mods.sln
@@ -7,6 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BabboSettings", "BabboSetti
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6D879749-9EB8-449B-9E5A-B8CD5B90DFA9}"
 	ProjectSection(SolutionItems) = preProject
+		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		LICENSE = LICENSE
 		README.md = README.md


### PR DESCRIPTION
adding an HDAdditionalLightData component to the game object so that we can set the volumetric dimmer to 0.  This prevents some of the ghosting seen on some of the maps with volumetric lighting.